### PR TITLE
HW05 Mikhail Vorobev

### DIFF
--- a/hw/app/Main.hs
+++ b/hw/app/Main.hs
@@ -1,28 +1,29 @@
 module Main where
+
 import Criterion.Main
+import TreeFusion (BinaryTree (..), binaryTreeTest, fusedBinaryTreeFoldrBuildTest, fusedBinaryTreeStreamTest)
 import Weigh
-import TreeFusion (BinaryTree(..), binaryTreeTest, fusedBinaryTreeFoldrBuildTest, fusedBinaryTreeStreamTest)
 
 n :: Int
 n = 1000000
 
 sampleBinaryTree :: BinaryTree Int
-sampleBinaryTree = go [1..n]
-    where
-        go [] = BinaryLeaf
-        go xs = BinaryNode (head xs) (go (take (length xs `div` 2) (drop 1 xs))) (go (drop (length xs `div` 2) (drop 1 xs)))
+sampleBinaryTree = go [1 .. n]
+  where
+    go [] = BinaryLeaf
+    go xs = BinaryNode (head xs) (go (take (length xs `div` 2) (drop 1 xs))) (go (drop (length xs `div` 2) (drop 1 xs)))
 
 memoryBenchmarks :: Weigh ()
 memoryBenchmarks = do
   func "not fused binary tree test" binaryTreeTest sampleBinaryTree
-  -- func "foldr/build fused binary tree test" fusedBinaryTreeFoldrBuildTest sampleBinaryTree -- uncomment this line when you implement the foldr/build version
+  func "foldr/build fused binary tree test" fusedBinaryTreeFoldrBuildTest sampleBinaryTree -- uncomment this line when you implement the foldr/build version
   -- func "stream fused binary tree test" fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
 
 main :: IO ()
 main = do
-    defaultMain [
-        bench "not fused binary tree test" $ whnf binaryTreeTest sampleBinaryTree
-        -- , bench "foldr/buils fused binary tree test" $ whnf fusedBinaryTreeFoldrBuildTest sampleBinaryTree -- uncomment this line when you implement the foldr/build version
-        -- , bench "stream fused binary tree test" $ whnf fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
-        ]
-    mainWith memoryBenchmarks
+  defaultMain
+    [ bench "not fused binary tree test" $ whnf binaryTreeTest sampleBinaryTree,
+      bench "foldr/buils fused binary tree test" $ whnf fusedBinaryTreeFoldrBuildTest sampleBinaryTree -- uncomment this line when you implement the foldr/build version
+      -- , bench "stream fused binary tree test" $ whnf fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
+    ]
+  mainWith memoryBenchmarks

--- a/hw/app/Main.hs
+++ b/hw/app/Main.hs
@@ -17,13 +17,13 @@ memoryBenchmarks :: Weigh ()
 memoryBenchmarks = do
   func "not fused binary tree test" binaryTreeTest sampleBinaryTree
   func "foldr/build fused binary tree test" fusedBinaryTreeFoldrBuildTest sampleBinaryTree -- uncomment this line when you implement the foldr/build version
-  -- func "stream fused binary tree test" fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
+  func "stream fused binary tree test" fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
 
 main :: IO ()
 main = do
   defaultMain
     [ bench "not fused binary tree test" $ whnf binaryTreeTest sampleBinaryTree,
-      bench "foldr/buils fused binary tree test" $ whnf fusedBinaryTreeFoldrBuildTest sampleBinaryTree -- uncomment this line when you implement the foldr/build version
-      -- , bench "stream fused binary tree test" $ whnf fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
+      bench "foldr/buils fused binary tree test" $ whnf fusedBinaryTreeFoldrBuildTest sampleBinaryTree, -- uncomment this line when you implement the foldr/build version
+      bench "stream fused binary tree test" $ whnf fusedBinaryTreeStreamTest sampleBinaryTree -- uncomment this line when you implement the stream version
     ]
   mainWith memoryBenchmarks

--- a/hw/app/TreeFusion.hs
+++ b/hw/app/TreeFusion.hs
@@ -44,17 +44,59 @@ fusedBinaryTreeFoldrBuildTest tree = foldrBinaryTreeFoldrBuild (\x l r -> (abs (
 
 -- Task 2
 
+data BStream a = forall s. BStream (s -> BStep a s) s
+
+data BStep a s = Branch a s s | Stop
+
+streamMap :: (a -> b) -> BStream a -> BStream b
+streamMap f (BStream g s) = BStream h s
+  where
+    h s' = case g s' of
+      Stop -> Stop
+      Branch x l r -> Branch (f x) l r
+
+streamFilter :: (a -> Bool) -> BStream a -> BStream a
+streamFilter p (BStream g s) = BStream h s
+  where
+    h s' = case g s' of
+      Stop -> Stop
+      Branch x l r -> if p x then Branch x l r else Stop
+
+streamFold :: (a -> b -> b -> b) -> b -> BStream a -> b
+streamFold f z (BStream g s) = go z s
+  where
+    go a s' = case g s' of
+      Stop -> a
+      Branch x l r -> f x (go a l) (go a r)
+
+streamify :: BinaryTree a -> BStream a
+streamify = BStream g
+  where
+    g BinaryLeaf = Stop
+    g (BinaryNode v l r) = Branch v l r
+{-# INLINE [0] streamify #-}
+
+unstreamify :: BStream a -> BinaryTree a
+unstreamify (BStream g s) = case g s of
+  Stop -> BinaryLeaf
+  Branch v l r -> BinaryNode v (unstreamify (BStream g l)) (unstreamify (BStream g r))
+{-# INLINE [0] unstreamify #-}
+
+{-# RULES
+"streamify/unstreamify" forall s. streamify (unstreamify s) = s
+  #-}
+
 mapBinaryTreeStream :: (a -> b) -> BinaryTree a -> BinaryTree b
-mapBinaryTreeStream = undefined
+mapBinaryTreeStream f = unstreamify . streamMap f . streamify
 
 filterBinaryTreeStream :: (a -> Bool) -> BinaryTree a -> BinaryTree a
-filterBinaryTreeStream = undefined
+filterBinaryTreeStream p = unstreamify . streamFilter p . streamify
 
-foldrBinaryTreeStream :: (b -> a -> b) -> b -> BinaryTree a -> b
-foldrBinaryTreeStream = undefined
+foldrBinaryTreeStream :: (a -> b -> b -> b) -> b -> BinaryTree a -> b
+foldrBinaryTreeStream f z = streamFold f z . streamify
 
 fusedBinaryTreeStreamTest :: BinaryTree Int -> Int
-fusedBinaryTreeStreamTest = undefined -- see binaryTreeTest
+fusedBinaryTreeStreamTest tree = foldrBinaryTreeStream (\x l r -> (abs ((abs r + 1) * l) + 1) * x) 1 ((mapBinaryTreeStream (+ 1) . filterBinaryTreeStream (\x -> x `rem` 400 /= 0) . mapBinaryTreeStream sqr) tree)
 
 -- Naive implementations for comparing performance and logic
 


### PR DESCRIPTION
```
benchmarking not fused binary tree test
time                 128.6 ms   (124.2 ms .. 134.6 ms)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 127.4 ms   (122.4 ms .. 129.9 ms)
std dev              5.353 ms   (2.244 ms .. 8.341 ms)
variance introduced by outliers: 11% (moderately inflated)

benchmarking foldr/buils fused binary tree test
time                 9.085 ms   (8.947 ms .. 9.247 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 8.973 ms   (8.883 ms .. 9.045 ms)
std dev              227.2 μs   (183.1 μs .. 321.7 μs)

benchmarking stream fused binary tree test
time                 5.121 ms   (5.102 ms .. 5.138 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.108 ms   (5.092 ms .. 5.125 ms)
std dev              51.05 μs   (41.13 μs .. 63.31 μs)


Case                             Allocated  GCs
not fused binary tree test     239,073,976   53
build fused binary tree test    45,990,760   11
stream fused binary tree test            0    0
```
Is it okay that I get 0 allocations in the stream implementation?